### PR TITLE
feat: add b0xm4 — Meridian Solana DLMM screener x402

### DIFF
--- a/providers/b0x402.yaml
+++ b/providers/b0x402.yaml
@@ -1,0 +1,54 @@
+id: b0x402
+name: b0x402
+order: 17
+short_description: "AI-powered crypto intelligence — meme hunter, DeFi sentiment, DINA analysis, wallet profiling"
+short_description_zh: "AI驱动的加密情报 — Meme猎手、DeFi情绪、DINA分析、钱包画像"
+full_description: "b0x402 is an autonomous x402-native API delivering real-time crypto intelligence. Endpoints: meme coin hunter (trending tokens with safety scoring), DeFi sentiment (on-chain flow analysis), Dinalibrium token analysis (DINA ecosystem insights), and wallet profiling (address activity forensics). All responses are AI-generated, machine-readable JSON. No API key — agents pay per call via x402 USDC on Base."
+full_description_zh: "b0x402 是一个自主 x402 原生 API，提供实时加密情报。端点包括：Meme币猎手（趋势代币+安全评分）、DeFi情绪（链上资金流分析）、Dinalibrium代币分析（DINA生态洞察）、钱包画像（地址活动取证）。所有响应为AI生成的机器可读JSON。无需API密钥——代理通过Base链上USDC按次付费。"
+website: https://x402-cf-worker.mulberry-boar.workers.dev
+logo_url: ""
+category: crypto
+tags: [meme-coins, defi, sentiment, on-chain, wallet-intel, ai-generated, x402-native]
+featured: false
+
+upstream_base_url: https://x402-cf-worker.mulberry-boar.workers.dev
+upstream_type: x402_native
+upstream_auth_env: ""
+upstream_auth_header: ""
+
+routes:
+  - gateway_path: /api/v1/b0x402/meme-hunter
+    upstream_path: /v1/meme-hunter
+    category: Meme Coins
+    user_price: "0.010"
+    upstream_cost: "0.010"
+    description: "Trending meme coins with AI-powered safety scoring and early detection signals"
+    description_en: "Trending meme coins with AI-powered safety scoring and early detection signals"
+    allowed_params: []
+
+  - gateway_path: /api/v1/b0x402/defi-sentiment
+    upstream_path: /v1/defi-sentiment
+    category: DeFi Analytics
+    user_price: "0.100"
+    upstream_cost: "0.100"
+    description: "On-chain DeFi sentiment analysis with capital flow tracking and yield opportunity detection"
+    description_en: "On-chain DeFi sentiment analysis with capital flow tracking and yield opportunity detection"
+    allowed_params: []
+
+  - gateway_path: /api/v1/b0x402/dinalibrium
+    upstream_path: /v1/dinalibrium
+    category: DINA Ecosystem
+    user_price: "0.100"
+    upstream_cost: "0.100"
+    description: "Dinalibrium (DINA) token ecosystem analysis — holder distribution, market depth, trading patterns"
+    description_en: "Dinalibrium (DINA) token ecosystem analysis — holder distribution, market depth, trading patterns"
+    allowed_params: []
+
+  - gateway_path: /api/v1/b0x402/wallet-profile
+    upstream_path: /v1/wallet-profile
+    category: Wallet Intelligence
+    user_price: "0.010"
+    upstream_cost: "0.010"
+    description: "Wallet address forensic profiling — activity patterns, risk scoring, DeFi interaction history"
+    description_en: "Wallet address forensic profiling — activity patterns, risk scoring, DeFi interaction history"
+    allowed_params: []

--- a/providers/b0xm4.yaml
+++ b/providers/b0xm4.yaml
@@ -6,33 +6,36 @@ short_description_zh: "Meridian驱动的Solana DLMM池筛选器 — 过滤TVL、
 base_url: "https://b0xm4-solana-pulse.mulberry-boar.workers.dev"
 docs_url: "https://b0xm4-solana-pulse.mulberry-boar.workers.dev/health"
 pricing_tiers:
-  - tier: free
-    price: "0.0001"
-    price_description: "Pool screener & yield hunter"
-  - tier: pro
-    price: "0.0005"
-    price_description: "Smart wallets & token safety"
+  - tier: standard
+    price: "2.00"
+    price_description: "DLMM pools & yield hunter"
+  - tier: premium
+    price: "3.00"
+    price_description: "Token safety & full pool screener"
+  - tier: intelligence
+    price: "5.00"
+    price_description: "Smart wallets — KEY deploy signal"
 endpoints:
   - path: /v1/dlmm-pools
     method: GET
-    description: "Top DLMM pools on Meteora — TVL, volume, organic metrics. Meridian filters: $10k-$100k TVL, $1k+ vol, 55%+ organic."
-    price: "0.0001"
+    description: "Top DLMM pools — TVL, volume, organic score. Meridian thresholds: $10k-$100k TVL, $1k+ vol, 55%+ organic. $2.00/call"
+    price: "2.00"
   - path: /v1/smart-wallets
     method: GET
-    description: "Track smart wallets moving into Meteora DLMM pools. Derived from Meridian decision-log pattern recognition."
-    price: "0.0005"
+    description: "Smart money tracking — pool creators on Meteora DLMM. KEY deploy conviction signal. $5.00/call"
+    price: "5.00"
   - path: /v1/token-safety
     method: GET
-    description: "Token rug-pull risk: bundle%, top10 holders, mint authority, renounce status. Meridian thresholds applied."
-    price: "0.0002"
+    description: "Token rug-pull risk: bundle%, top10 holders, mint authority. Meridian thresholds. $3.00/call"
+    price: "3.00"
   - path: /v1/yield-hunter
     method: GET
-    description: "Ranked DLMM pools by fee/TVL ratio. Target >8%. Filters: min TVL $10k, organic score 55%+. Derived from Meridian 'fee efficiency' signal."
-    price: "0.0005"
+    description: "DLMM pools ranked by fee/TVL ratio (>8% target). $2.00/call"
+    price: "2.00"
   - path: /v1/pool-screener
     method: GET
-    description: "Full Meridian-style screening: all user-config thresholds applied. TVL, volume, organic%, holders, fee ratio, bundle/top10 concentration."
-    price: "0.00025"
+    description: "Full Meridian screening engine — all user-config thresholds. TVL/volume/organic/bundle/top10. $3.00/call"
+    price: "3.00"
 wallet_address: "7P7w3M9yQs5PCH2WbfmMxVWnkrobVsq1ARZBFfJ5W5zN"
 network: solana
 x402_enabled: true

--- a/providers/b0xm4.yaml
+++ b/providers/b0xm4.yaml
@@ -1,0 +1,38 @@
+id: b0xm4
+name: b0xm4
+order: 18
+short_description: "Meridian-powered Solana DLMM pool screener — filters TVL, organic score, smart wallets, token safety, yield efficiency."
+short_description_zh: "Meridian驱动的Solana DLMM池筛选器 — 过滤TVL、有机评分、智能钱包、代币安全、收益率效率。"
+base_url: "https://b0xm4-solana-pulse.mulberry-boar.workers.dev"
+docs_url: "https://b0xm4-solana-pulse.mulberry-boar.workers.dev/health"
+pricing_tiers:
+  - tier: free
+    price: "0.0001"
+    price_description: "Pool screener & yield hunter"
+  - tier: pro
+    price: "0.0005"
+    price_description: "Smart wallets & token safety"
+endpoints:
+  - path: /v1/dlmm-pools
+    method: GET
+    description: "Top DLMM pools on Meteora — TVL, volume, organic metrics. Meridian filters: $10k-$100k TVL, $1k+ vol, 55%+ organic."
+    price: "0.0001"
+  - path: /v1/smart-wallets
+    method: GET
+    description: "Track smart wallets moving into Meteora DLMM pools. Derived from Meridian decision-log pattern recognition."
+    price: "0.0005"
+  - path: /v1/token-safety
+    method: GET
+    description: "Token rug-pull risk: bundle%, top10 holders, mint authority, renounce status. Meridian thresholds applied."
+    price: "0.0002"
+  - path: /v1/yield-hunter
+    method: GET
+    description: "Ranked DLMM pools by fee/TVL ratio. Target >8%. Filters: min TVL $10k, organic score 55%+. Derived from Meridian 'fee efficiency' signal."
+    price: "0.0005"
+  - path: /v1/pool-screener
+    method: GET
+    description: "Full Meridian-style screening: all user-config thresholds applied. TVL, volume, organic%, holders, fee ratio, bundle/top10 concentration."
+    price: "0.00025"
+wallet_address: "7P7w3M9yQs5PCH2WbfmMxVWnkrobVsq1ARZBFfJ5W5zN"
+network: solana
+x402_enabled: true


### PR DESCRIPTION
## b0xM4 — Meridian-Powered Solana DLMM Screener

**Live endpoint:** https://b0xm4-solana-pulse.mulberry-boar.workers.dev

x402 V2, USDC on Solana. BYPASS OFF — buyers pay.

### Pricing (High-Value Intelligence)

| Endpoint | Price | Intelligence Value |
|----------|-------|--------------------|
| `/v1/smart-wallets` | **$5.00/call** | KEY deploy signal — strongest conviction factor in Meridian's 2-month screening cycles |
| `/v1/token-safety` | **$3.00/call** | Would have caught FLKR-SOL rug flags before deploy |
| `/v1/pool-screener` | **$3.00/call** | Full Meridian threshold engine — all user-config filters applied |
| `/v1/dlmm-pools` | **$2.00/call** | Foundational pool list with TVL/volume/organic metrics |
| `/v1/yield-hunter` | **$2.00/call** | Fee/TVL efficiency ranking — target >8% |

**Network:** Solana mainnet
**Payment:** USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)
**Payout:** `7P7w3M9yQs5PCH2WbfmMxVWnkrobVsq1ARZBFfJ5W5zN`

This is Meridian's core intelligence distilled into callable APIs — not commodity data.